### PR TITLE
feat: add registration_certificate or intended_use_id to OID4VP Verifier request

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,9 @@ REACT_APP_CLIENT_BASE_URL=
 
 # ---------- OID4VP Configuration ----------
 VERIFIER-DOMAIN=verifier-backend.eudiw.dev
-WALLET-SCHEME=eudi-openid4vp://
+WALLET-SCHEME=haip-vp://
+INTENDED-USE-ID= # The identifier of configured Wallet Relying Party Intended Uses if one is made available by the verifier
+REGISTRATION-CERTIFICATE-JWT= # a Wallet Relying Party Registration Certificate to be used
 ```
 
 ## Local Deployment
@@ -534,7 +536,9 @@ spring:
 
    This application requires users to authenticate and authorize the signature of documents with certificates they own through their EUDI Wallet.
    To enable this feature (authentication using PID), communication with a backend Verifier that supports OID4VP v1 is required.
-   It is mandatory to configure the domain and wallet scheme for OID4VP. TThis can be done in one of two ways:
+   It is mandatory to configure the domain and wallet scheme for OID4VP. You must also specify the registration certificate to use,
+   either by providing an `intended_use_id` (if the Verifier has a default test certificate configured) or a `registration_certificate_jwt`.
+   This can be done in one of two ways:
 
    1. By updating the **application.yml** located in the folder **authorization_server/src/main/resources**:
    ```
@@ -543,14 +547,18 @@ spring:
        domain: ${VERIFIER-DOMAIN}
        presentation-url: https://${VERIFIER-DOMAIN}/ui/presentations
        validation-url: https://${VERIFIER-DOMAIN}/utilities/validations/msoMdoc/deviceResponse
-     wallet:
+       intended_use_id: ${INTENDED-USE-ID}
+       registration_certificate_Jwt: ${REGISTRATION-CERTIFICATE-JWT}  
+   wallet:
        scheme: ${WALLET-SCHEME}
    ```
    
    2. By setting environment variables in a .env file. Example:
    ```
    VERIFIER-DOMAIN=verifier-backend.eudiw.dev
-   WALLET-SCHEME=eudi-openid4vp://
+   WALLET-SCHEME=haip-vp://
+   INTENDED-USE-ID=
+   REGISTRATION-CERTIFICATE-JWT=
    ```
 
    When a user wants to authenticate or sign a document, the server communicates with the Verifier and redirects the user to the EUDI Wallet. The result of this process is vp_tokens. The application then validates the vp_tokens received from the Verifier.

--- a/README.md
+++ b/README.md
@@ -458,6 +458,10 @@ ASSINA_CLIENT_BASE_URL=
 REACT_APP_APP_BASE_URL=
 REACT_APP_SA_BASE_URL=
 REACT_APP_CLIENT_BASE_URL=
+
+# ---------- OID4VP Configuration ----------
+VERIFIER-DOMAIN=verifier-backend.eudiw.dev
+WALLET-SCHEME=eudi-openid4vp://
 ```
 
 ## Local Deployment
@@ -529,22 +533,24 @@ spring:
 4. **Authentication using OpenId4VP**
 
    This application requires users to authenticate and authorize the signature of documents with certificates they own through their EUDI Wallet.
-   To enable this feature, communication with a backend **Verifier** is necessary. Define the address, URL and the client*id of the Verifier by adding the configuration in **application.yml** located in the folder \_server/app/src/main/resources*:
+   To enable this feature (authentication using PID), communication with a backend Verifier that supports OID4VP v1 is required.
+   It is mandatory to configure the domain and wallet scheme for OID4VP. TThis can be done in one of two ways:
 
+   1. By updating the **application.yml** located in the folder **authorization_server/src/main/resources**:
    ```
-   verifier:
-      url:
-      address:
-      client_id:
+   oid4vp:
+     verifier:
+       domain: ${VERIFIER-DOMAIN}
+       presentation-url: https://${VERIFIER-DOMAIN}/ui/presentations
+       validation-url: https://${VERIFIER-DOMAIN}/utilities/validations/msoMdoc/deviceResponse
+     wallet:
+       scheme: ${WALLET-SCHEME}
    ```
-
-   By default, this configuration is set to a backend server based on the code from the github **'eu-digital-identity-wallet/eudi-srv-web-verifier-endpoint-23220-4-kt'**. Therefore, the default configuration is:
-
+   
+   2. By setting environment variables in a .env file. Example:
    ```
-   verifier:
-      url: https://verifier-backend.eudiw.dev/ui/presentations
-      address: verifier-backend.eudiw.dev
-      client_id: verifier-backend.eudiw.dev
+   VERIFIER-DOMAIN=verifier-backend.eudiw.dev
+   WALLET-SCHEME=eudi-openid4vp://
    ```
 
    When a user wants to authenticate or sign a document, the server communicates with the Verifier and redirects the user to the EUDI Wallet. The result of this process is vp_tokens. The application then validates the vp_tokens received from the Verifier.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.7.0]
+_X Fev 2026_
+
+### Changed
+- Updated OID4VP configuration: the wallet scheme and verifier domain are now configurable via environment variables.
+
 ## [0.6.0]
 _7 Nov 2025_
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,11 @@
 # Changelog
 
 ## [0.7.0]
-_X Fev 2026_
+_17 Aug 2026_
 
 ### Changed
 - Updated OID4VP configuration: the wallet scheme and verifier domain are now configurable via environment variables.
+- Updated OID4VP requests to specify either a registration certificate or intended use on Verifier requests.
 
 ## [0.6.0]
 _7 Nov 2025_

--- a/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/RSSPApplication.java
+++ b/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/RSSPApplication.java
@@ -40,7 +40,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
-@EnableConfigurationProperties({ JwtConfigProperties.class, CSCProperties.class, VerifierProperties.class, CertificatesProperties.class, TrustedIssuersCertificatesProperties.class, AuthProperties.class, SADProperties.class, KeysProperties.class })
+@EnableConfigurationProperties({ JwtConfigProperties.class, CSCProperties.class, OID4VPConfig.class, CertificatesProperties.class, TrustedIssuersCertificatesProperties.class, AuthProperties.class, SADProperties.class, KeysProperties.class })
 public class RSSPApplication {
     private static final Logger logger = LoggerFactory.getLogger(RSSPApplication.class);
 

--- a/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/common/config/OID4VPConfig.java
+++ b/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/common/config/OID4VPConfig.java
@@ -1,11 +1,15 @@
 package eu.europa.ec.eudi.signer.rssp.common.config;
 
+import jakarta.validation.Valid;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.validation.annotation.Validated;
 
 @PropertySource("file:application.yml")
 @ConfigurationProperties(prefix = "oid4vp")
+@Validated
 public class OID4VPConfig {
+	@Valid
 	private VerifierProperties verifier;
 	private WalletConfig wallet;
 

--- a/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/common/config/OID4VPConfig.java
+++ b/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/common/config/OID4VPConfig.java
@@ -1,0 +1,39 @@
+package eu.europa.ec.eudi.signer.rssp.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+
+@PropertySource("file:application.yml")
+@ConfigurationProperties(prefix = "oid4vp")
+public class OID4VPConfig {
+	private VerifierProperties verifier;
+	private WalletConfig wallet;
+
+	public VerifierProperties getVerifier() {
+		return verifier;
+	}
+
+	public void setVerifier(VerifierProperties verifier) {
+		this.verifier = verifier;
+	}
+
+	public WalletConfig getWallet() {
+		return wallet;
+	}
+
+	public void setWallet(WalletConfig wallet) {
+		this.wallet = wallet;
+	}
+
+	public static class WalletConfig{
+		private String scheme;
+
+		public String getScheme() {
+			return scheme;
+		}
+
+		public void setScheme(String scheme) {
+			this.scheme = scheme;
+		}
+	}
+}

--- a/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/common/config/VerifierProperties.java
+++ b/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/common/config/VerifierProperties.java
@@ -16,37 +16,32 @@
 
 package eu.europa.ec.eudi.signer.rssp.common.config;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.PropertySource;
-
-@PropertySource("file:application.yml")
-@ConfigurationProperties(prefix = "verifier")
 public class VerifierProperties {
-    private String url;
-    private String address;
-    private String clientId;
+    private String domain;
+    private String presentationUrl;
+    private String validationUrl;
 
-    public String getUrl() {
-        return this.url;
+    public String getDomain() {
+        return domain;
     }
 
-    public void setUrl(String url) {
-        this.url = url;
+    public void setDomain(String domain) {
+        this.domain = domain;
     }
 
-    public String getAddress() {
-        return this.address;
+    public String getPresentationUrl() {
+        return presentationUrl;
     }
 
-    public void setAddress(String address) {
-        this.address = address;
+    public void setPresentationUrl(String presentationUrl) {
+        this.presentationUrl = presentationUrl;
     }
 
-    public String getClientId() {
-        return clientId;
+    public String getValidationUrl() {
+        return validationUrl;
     }
 
-    public void setClientId(String clientId) {
-        this.clientId = clientId;
+    public void setValidationUrl(String validationUrl) {
+        this.validationUrl = validationUrl;
     }
 }

--- a/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/common/config/VerifierProperties.java
+++ b/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/common/config/VerifierProperties.java
@@ -16,10 +16,20 @@
 
 package eu.europa.ec.eudi.signer.rssp.common.config;
 
+import jakarta.validation.constraints.AssertTrue;
+
 public class VerifierProperties {
     private String domain;
     private String presentationUrl;
     private String validationUrl;
+    private String intendedUseId;
+    private String registrationCertificateJwt;
+
+    @AssertTrue(message = "Either 'intendedUseId' or 'registrationCertificateId' must be defined")
+    private boolean isIntendedUseOrRegistrationCertificateValid() {
+        return (intendedUseId != null && !intendedUseId.isBlank())
+              || (registrationCertificateJwt != null && !registrationCertificateJwt.isBlank());
+    }
 
     public String getDomain() {
         return domain;
@@ -43,5 +53,21 @@ public class VerifierProperties {
 
     public void setValidationUrl(String validationUrl) {
         this.validationUrl = validationUrl;
+    }
+
+    public String getIntendedUseId() {
+        return intendedUseId;
+    }
+
+    public void setIntendedUseId(String intendedUseId) {
+        this.intendedUseId = intendedUseId;
+    }
+
+    public String getRegistrationCertificateJwt() {
+        return registrationCertificateJwt;
+    }
+
+    public void setRegistrationCertificateJwt(String registrationCertificateJwt) {
+        this.registrationCertificateJwt = registrationCertificateJwt;
     }
 }

--- a/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/security/openid4vp/VerifierClient.java
+++ b/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/security/openid4vp/VerifierClient.java
@@ -23,6 +23,7 @@ import java.security.SecureRandom;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+import eu.europa.ec.eudi.signer.rssp.common.config.OID4VPConfig;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.json.JSONException;
@@ -34,7 +35,6 @@ import org.springframework.stereotype.Component;
 import eu.europa.ec.eudi.signer.common.FailedConnectionVerifier;
 import eu.europa.ec.eudi.signer.common.TimeoutException;
 import eu.europa.ec.eudi.signer.csc.payload.RedirectLinkResponse;
-import eu.europa.ec.eudi.signer.rssp.common.config.VerifierProperties;
 import eu.europa.ec.eudi.signer.rssp.common.error.ApiException;
 import eu.europa.ec.eudi.signer.rssp.common.error.SignerError;
 import eu.europa.ec.eudi.signer.rssp.util.WebUtils;
@@ -50,11 +50,11 @@ public class VerifierClient {
     public static String PRESENTATION_DEFINITION_INPUT_DESCRIPTORS_ID = "eu.europa.ec.eudi.pid.1";
 
     private static final Logger log = LoggerFactory.getLogger(VerifierClient.class);
-    private final VerifierProperties verifierProperties;
+    private final OID4VPConfig oid4VPConfig;
     private final VerifierCreatedVariables verifierVariables;
 
-    public VerifierClient(VerifierProperties verifierProperties) {
-        this.verifierProperties = verifierProperties;
+    public VerifierClient(OID4VPConfig oid4VPConfig) {
+        this.oid4VPConfig = oid4VPConfig;
         this.verifierVariables = new VerifierCreatedVariables();
     }
 
@@ -193,7 +193,7 @@ public class VerifierClient {
         HttpResponse response;
         log.info("Making request to Verifier: {}", presentationDefinition);
         try {
-            response = WebUtils.httpPostRequest(verifierProperties.getUrl(), headers, presentationDefinition);
+            response = WebUtils.httpPostRequest(this.oid4VPConfig.getVerifier().getPresentationUrl(), headers, presentationDefinition);
         } catch (Exception e) {
             log.error("An error occurred when trying to connect to the Verifier. {}", e.getMessage());
             throw new Exception("An error occurred when trying to connect to the Verifier");
@@ -248,10 +248,6 @@ public class VerifierClient {
 		log.info("Request URI: {}", request_uri);
         String client_id = responseFromVerifier.getString("client_id");
 		log.info("Client Id: {}", client_id);
-        /*if(!client_id.contains(this.verifierProperties.getClientId())){
-            log.error(SignerError.UnexpectedError.getFormattedMessage());
-            throw new ApiException(SignerError.UnexpectedError, SignerError.UnexpectedError.getFormattedMessage());
-        }*/
         String presentation_id = responseFromVerifier.getString("transaction_id");
 		log.info("Transaction Id: {}", presentation_id);
         String encoded_request_uri = URLEncoder.encode(request_uri, StandardCharsets.UTF_8);
@@ -265,7 +261,7 @@ public class VerifierClient {
     }
 
     private String redirectUriDeepLink(String request_uri, String client_id) {
-        return "eudi-openid4vp://" + verifierProperties.getAddress() + "?client_id=" + client_id + "&request_uri=" + request_uri;
+        return this.oid4VPConfig.getWallet().getScheme() + this.oid4VPConfig.getVerifier().getDomain() + "?client_id=" + client_id + "&request_uri=" + request_uri;
     }
 
     /**
@@ -376,10 +372,10 @@ public class VerifierClient {
     }
 
     private String uriToRequestWalletPID(String presentation_id, String nonce) {
-        return verifierProperties.getUrl() + "/" + presentation_id + "?nonce=" + nonce;
+        return this.oid4VPConfig.getVerifier().getPresentationUrl() + "/" + presentation_id + "?nonce=" + nonce;
     }
 
     private String getUrlToRetrieveVPTokenWithResponseCode(String presentation_id, String nonce, String code) {
-        return verifierProperties.getUrl() + "/" + presentation_id + "?nonce=" + nonce + "&response_code=" + code;
+        return this.oid4VPConfig.getVerifier().getPresentationUrl() + "/" + presentation_id + "?nonce=" + nonce + "&response_code=" + code;
     }
 }

--- a/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/security/openid4vp/VerifierClient.java
+++ b/server/app/src/main/java/eu/europa/ec/eudi/signer/rssp/security/openid4vp/VerifierClient.java
@@ -159,25 +159,28 @@ public class VerifierClient {
         return new JSONObject(dcqlQuery);
     }
 
-    private String getInitTransactionCrossDeviceBody(String nonce) {
+    private JSONObject getCommonStructureMessage(String nonce) {
         JSONObject dcqlQueryJSON = getDCQLQueryJSON();
 
         JSONObject jsonBodyToInitPresentation = new JSONObject();
         jsonBodyToInitPresentation.put("type", "vp_token");
         jsonBodyToInitPresentation.put("nonce", nonce);
         jsonBodyToInitPresentation.put("dcql_query", dcqlQueryJSON);
-        return jsonBodyToInitPresentation.toString();
+        String registrationCertificate = oid4VPConfig.getVerifier().getRegistrationCertificateJwt();
+        if(registrationCertificate != null && !registrationCertificate.isBlank())
+            jsonBodyToInitPresentation.put("registration_certificate", registrationCertificate);
+        else
+            jsonBodyToInitPresentation.put("intended_use_id", oid4VPConfig.getVerifier().getIntendedUseId());
+        return jsonBodyToInitPresentation;
+    }
+
+    private String getInitTransactionCrossDeviceBody(String nonce) {
+        return getCommonStructureMessage(nonce).toString();
     }
 
     private String getInitTransactionSameDeviceBody(String user, String nonce, String redirect_uri) {
-        JSONObject dcqlQueryJSON = getDCQLQueryJSON();
-
         String redirectUri = redirect_uri+"?session_id="+user+"&response_code={RESPONSE_CODE}";
-
-        JSONObject jsonBodyToInitPresentation = new JSONObject();
-        jsonBodyToInitPresentation.put("type", "vp_token");
-        jsonBodyToInitPresentation.put("nonce", nonce);
-        jsonBodyToInitPresentation.put("dcql_query", dcqlQueryJSON);
+        JSONObject jsonBodyToInitPresentation = getCommonStructureMessage(nonce);jsonBodyToInitPresentation.put("wallet_response_redirect_uri_template", redirectUri);
         jsonBodyToInitPresentation.put("wallet_response_redirect_uri_template", redirectUri);
         return jsonBodyToInitPresentation.toString();
     }

--- a/server/app/src/main/resources/application.yml
+++ b/server/app/src/main/resources/application.yml
@@ -45,10 +45,12 @@ sad:
     lifetimeMinutes: 5
     secret: ${AUTH_SAD_TOKEN_SECRET}
 
-verifier:
-    url: https://verifier-backend.eudiw.dev/ui/presentations
-    address: verifier-backend.eudiw.dev
-    client_id: verifier-backend.eudiw.dev
+oid4vp:
+    verifier:
+        domain: ${VERIFIER-DOMAIN}
+        presentation-url: https://${VERIFIER-DOMAIN}/ui/presentations
+    wallet:
+        scheme: ${WALLET-SCHEME}
 
 trusted-issuers:
     folder: issuersCertificates

--- a/server/app/src/main/resources/application.yml
+++ b/server/app/src/main/resources/application.yml
@@ -49,6 +49,8 @@ oid4vp:
     verifier:
         domain: ${VERIFIER-DOMAIN}
         presentation-url: https://${VERIFIER-DOMAIN}/ui/presentations
+        intended_use_id: ${INTENDED-USE-ID:}
+        registration_certificate_Jwt: ${REGISTRATION-CERTIFICATE-JWT:}
     wallet:
         scheme: ${WALLET-SCHEME}
 


### PR DESCRIPTION
Updated OID4VP requests to specify either a registration certificate or intended use on Verifier requests.